### PR TITLE
Change award initial id in database as 100

### DIFF
--- a/lucky_draw/priv/repo/migrations/20210113133430_create_awards_table.exs
+++ b/lucky_draw/priv/repo/migrations/20210113133430_create_awards_table.exs
@@ -10,5 +10,7 @@ defmodule LuckyDraw.Repo.Migrations.CreateAwardsTable do
 
       timestamps()
     end
+
+    execute "ALTER SEQUENCE awards_id_seq RESTART WITH 100;"
   end
 end


### PR DESCRIPTION
## Summary

It's a workaround for avoid inserting conflict id into database when seed data exist.